### PR TITLE
Don’t remove last char when deadkey is pressed.

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -90,8 +90,8 @@ window.addEventListener('DOMContentLoaded', () => {
    * want for a keyboard layout emulation. The code below works around that.
    */
   input.addEventListener('input', (event) => {
-    if (event.inputType === 'insertCompositionText'
-      || event.inputType === 'insertText') {
+    if ((event.inputType === 'insertCompositionText'
+      || event.inputType === 'insertText') && event.isComposing) {
       event.target.value = event.target.value.slice(0, -event.data.length);
     }
   });


### PR DESCRIPTION
As I stated in #29, dead keys remove the last character of the input field. I included a gif bellow to show how to reproduce the bug (just type something, then input a dead key other than `1dk`).

![output](https://github.com/fabi1cazenave/x-keyboard/assets/70967142/b829fb75-afe0-424e-b324-a43d5a5cd433)

This is because when a deadkey is pressed, the [event listner in `demo.js`](https://github.com/fabi1cazenave/x-keyboard/blob/master/demo.js#L92-L97) is called twice in quick succession. It’s supposed to be called once, to delete the key hint the browser automatically writes (since x-keyboard gives way better hints), but the extra call also deletes another character.

Logging those events (see gif, on the right hand side) shows they are basically the same, except the first event has the `isComposing` field set to `true` and the second one to `false`.

Removing the last char only when `event.isComposing` is set to `true` fixes that problem, and seems to be the only event we care about, if I understand [MDN’s documentation](https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/isComposing) correctly, though there may be an edge case I don’t know about (god knows JS has a lot of those…).